### PR TITLE
add -DskipTests=true, fixes #39

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,6 @@ matrix:
       before_install:
         - cd ./quix-backend
       install:
-        - mvn install
+        - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
       script:
         - mvn test


### PR DESCRIPTION
should fix https://github.com/wix-incubator/quix/issues/39

according to https://docs.travis-ci.com/user/languages/java/#maven-dependency-management
mvn install should be used with -DskipTests=true option