### PR TITLE
Fix truncated error messages

### DIFF
--- a/quix-frontend/client/package-lock.json
+++ b/quix-frontend/client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wix/quix-client",
-  "version": "1.0.108",
+  "version": "1.0.131",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1932,9 +1932,9 @@
       }
     },
     "@wix/quix-shared": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@wix/quix-shared/-/quix-shared-1.0.14.tgz",
-      "integrity": "sha512-WgisvycQakw9oPgutYv8+x6F0ZMXbmSMKxkdU0tkg77glEBaQvEeI48IyEcaLT2+Y/fLdT+ZglgNlyo5sAI8Sw==",
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@wix/quix-shared/-/quix-shared-1.0.15.tgz",
+      "integrity": "sha512-mwnFHwwBdcomEpBjqHnx3Whgr9kusNfn/U1tmVRp0m5iTDLj65enZM1lkGKpeNVix3ybBJFjJK8lqNvusmfJpQ==",
       "requires": {
         "lodash": "^4.17.11",
         "tslib": "^2.3.0",

--- a/quix-frontend/client/src/lib/runner/directives/runner/runner.scss
+++ b/quix-frontend/client/src/lib/runner/directives/runner/runner.scss
@@ -81,6 +81,11 @@ bi-runner {
       display: flex;
       height: 300px;
       flex-direction: column;
+
+      .bi-empty-state-content.bi-danger {
+        white-space: pre-wrap;
+        overflow-y: auto;
+      }
     }
 
     &.br-result-with-tabs {

--- a/quix-frontend/client/test/dev/websocket-mock.ts
+++ b/quix-frontend/client/test/dev/websocket-mock.ts
@@ -56,7 +56,16 @@ const failEvents = [
   {event: 'query-details', data: {id: '20190506_152226_00201_xps63', 'code': 'select a'}},
   {event: 'percentage', data: {id: '20190506_152226_00201_xps63', 'percentage': 0}},
   {event: 'percentage', data: {id: '20190506_152226_00201_xps63', 'percentage': 0}},
-  {event: 'error', data: {id: '20190506_152226_00201_xps63', 'message': 'line 1:8: Column \'a\' cannot be resolved'}},
+  {event: 'error', data: {id: '20190506_152226_00201_xps63', 'message': `ClickHouseUnknownException(ClickHouse exception, code: 1002, host: sys-ch-fedology0a.42.wixprod.net, port: 8123; Code: 62. DB::Exception: Syntax error: failed at position 249 ('data') (line 8, col 5): data,
+  message,
+  error_stack
+FROM
+  logs_db.panorama
+WHERE
+(1 = 0 or toDateTime(date_created) > now() - INTERVAL 1 DAY)
+  AND log_level = 'ERROR'
+ . Expected one of: token, Comma, FROM, PREWHERE, WHERE, GROUP BY, WITH, HAVING, WINDOW, ORDER BY, LIMIT, OFFSET, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, end of query. (SYNTAX_ERROR) (version 22.8.4.7 (official build))
+)`}},
   {event: 'query-end', data: {id: '20190506_152226_00201_xps63'}},
   {event: 'end', data: {id: '274370d2-6755-4d3c-8248-b573a63523d2'}}
 ];

--- a/quix-frontend/client/test/dev/websocket-mock.ts
+++ b/quix-frontend/client/test/dev/websocket-mock.ts
@@ -56,15 +56,15 @@ const failEvents = [
   {event: 'query-details', data: {id: '20190506_152226_00201_xps63', 'code': 'select a'}},
   {event: 'percentage', data: {id: '20190506_152226_00201_xps63', 'percentage': 0}},
   {event: 'percentage', data: {id: '20190506_152226_00201_xps63', 'percentage': 0}},
-  {event: 'error', data: {id: '20190506_152226_00201_xps63', 'message': `ClickHouseUnknownException(ClickHouse exception, code: 1002, host: sys-ch-fedology0a.42.wixprod.net, port: 8123; Code: 62. DB::Exception: Syntax error: failed at position 249 ('data') (line 8, col 5): data,
+  {event: 'error', data: {id: '20190506_152226_00201_xps63', 'message': `ClickHouseUnknownException(ClickHouse exception, code: 1002, host: foo.goo.net, port: 3000; Code: 20. DB::Exception: Syntax error: failed at position 249 ('data') (line 8, col 5): data,
   message,
   error_stack
 FROM
-  logs_db.panorama
+  foo.goo
 WHERE
 (1 = 0 or toDateTime(date_created) > now() - INTERVAL 1 DAY)
   AND log_level = 'ERROR'
- . Expected one of: token, Comma, FROM, PREWHERE, WHERE, GROUP BY, WITH, HAVING, WINDOW, ORDER BY, LIMIT, OFFSET, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, end of query. (SYNTAX_ERROR) (version 22.8.4.7 (official build))
+ . Expected one of: token, Comma, FROM, PREWHERE, WHERE, GROUP BY, WITH, HAVING, WINDOW, ORDER BY, LIMIT, OFFSET, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, end of query. (SYNTAX_ERROR) (version 1.1.1 (official build))
 )`}},
   {event: 'query-end', data: {id: '20190506_152226_00201_xps63'}},
   {event: 'end', data: {id: '274370d2-6755-4d3c-8248-b573a63523d2'}}

--- a/quix-frontend/client/test/mocks.ts
+++ b/quix-frontend/client/test/mocks.ts
@@ -21,7 +21,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export const MockNoteContent = {
   success: 'do success',
-  error: 'do permission error',
+  error: 'do error',
   permissionError: 'do permission error',
   sql: 'do SQL',
 };
@@ -102,15 +102,12 @@ const mocks = {
           name: 'Runnable (permission error)',
           content: MockNoteContent.permissionError,
         }),
-        createMockNote(id, { id: `${noteId++}`, content: 'select 1' }),
         createMockNote(id, {
           id: `${noteId++}`,
           name: 'Runnable SQL+JSON Result (Timeout)',
           content: MockNoteContent.sql,
           type: 'python',
         }),
-        createMockNote(id, { id: `${noteId++}` }),
-        createMockNote(id, { id: `${noteId++}` }),
       ],
       {
         id,

--- a/quix-frontend/shared/package-lock.json
+++ b/quix-frontend/shared/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wix/quix-shared",
-	"version": "1.0.14",
+	"version": "1.0.15",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Long error messages are truncated, which makes them very hard to read.
This PR makes sure the error messages don't overflow the container and makes them scrollable.

