### PR TITLE
Fix truncated errors

### DIFF
--- a/quix-frontend/client/src/lib/runner/directives/runner/runner.scss
+++ b/quix-frontend/client/src/lib/runner/directives/runner/runner.scss
@@ -81,6 +81,11 @@ bi-runner {
       display: flex;
       height: 300px;
       flex-direction: column;
+
+      .bi-empty-state-content.bi-danger {
+        white-space: pre-wrap;
+        overflow-y: auto;
+      }
     }
 
     &.br-result-with-tabs {

--- a/quix-frontend/client/test/dev/websocket-mock.ts
+++ b/quix-frontend/client/test/dev/websocket-mock.ts
@@ -56,7 +56,16 @@ const failEvents = [
   {event: 'query-details', data: {id: '20190506_152226_00201_xps63', 'code': 'select a'}},
   {event: 'percentage', data: {id: '20190506_152226_00201_xps63', 'percentage': 0}},
   {event: 'percentage', data: {id: '20190506_152226_00201_xps63', 'percentage': 0}},
-  {event: 'error', data: {id: '20190506_152226_00201_xps63', 'message': 'line 1:8: Column \'a\' cannot be resolved'}},
+  {event: 'error', data: {id: '20190506_152226_00201_xps63', 'message': `UnknownException(UnknownException exception, code: 1002, host: foo.goo.net, port: 3000; Code: 20. DB::Exception: Syntax error: failed at position 249 ('a') (line 8, col 5): a,
+  b,
+  c
+FROM
+  foo.goo
+WHERE
+(1 = 0 or toDateTime(a) > now() - INTERVAL 1 DAY)
+  AND b = 'ERROR'
+ . Expected one of: token, Comma, FROM, PREWHERE, WHERE, GROUP BY, WITH, HAVING, WINDOW, ORDER BY, LIMIT, OFFSET, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, end of query. (SYNTAX_ERROR) (version 1.1.1 (official build))
+)`}},
   {event: 'query-end', data: {id: '20190506_152226_00201_xps63'}},
   {event: 'end', data: {id: '274370d2-6755-4d3c-8248-b573a63523d2'}}
 ];

--- a/quix-frontend/client/test/mocks.ts
+++ b/quix-frontend/client/test/mocks.ts
@@ -21,7 +21,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export const MockNoteContent = {
   success: 'do success',
-  error: 'do permission error',
+  error: 'do error',
   permissionError: 'do permission error',
   sql: 'do SQL',
 };
@@ -102,15 +102,12 @@ const mocks = {
           name: 'Runnable (permission error)',
           content: MockNoteContent.permissionError,
         }),
-        createMockNote(id, { id: `${noteId++}`, content: 'select 1' }),
         createMockNote(id, {
           id: `${noteId++}`,
           name: 'Runnable SQL+JSON Result (Timeout)',
           content: MockNoteContent.sql,
           type: 'python',
         }),
-        createMockNote(id, { id: `${noteId++}` }),
-        createMockNote(id, { id: `${noteId++}` }),
       ],
       {
         id,


### PR DESCRIPTION
Long error messages are truncated, which makes them very hard to read.
This PR makes sure the error messages don't overflow the container and makes them scrollable.

Before:

![image](https://github.com/wix-incubator/quix/assets/7899596/b6604c56-b024-4004-8b76-b206054a45dd)

After:

![image](https://github.com/wix-incubator/quix/assets/7899596/514aa9be-d731-4490-80e8-51e77877815b)
